### PR TITLE
use multiple shards per index

### DIFF
--- a/pm2os.py
+++ b/pm2os.py
@@ -42,6 +42,13 @@ TARGETS = [
     }
 ]
 
+SETTINGS = {
+    "index": {
+        "number_of_shards": 3,
+        "number_of_replicas": 1,
+    }
+}
+
 # Set the index name with format sflow-YYYY.MM.DD
 now = datetime.utcnow()
 INDEX_NAME = f"sflow-{now.strftime('%Y.%m.%d')}"
@@ -64,7 +71,7 @@ def create_index_if_needed(target):
         try:
             create_index_response = requests.put(
                 full_index_url,
-                json={"settings": {}, "mappings": {}},
+                json={"settings": SETTINGS, "mappings": {}},
                 auth=target['auth'],
                 verify=False
             )


### PR DESCRIPTION
An empty `settings` dict results in one shard and one replica, which has led to noticeably unbalanced data distribution on the IL3 opensearch cluster.  I cowboyed a change like this last week (the copy of pm2os.py on there seems to pre-date the multi-target work) and each node now has almost the same amount of data on it.